### PR TITLE
Fixes #31

### DIFF
--- a/MG.Sonarr-DotNet/Cmdlets/Calendar/GetCalendar.cs
+++ b/MG.Sonarr-DotNet/Cmdlets/Calendar/GetCalendar.cs
@@ -82,6 +82,15 @@ namespace MG.Sonarr.Cmdlets
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
+            if (this.ContainsParameter(x => x.DayOfWeek) && !this.ContainsParameter(x => x.StartDate))
+            {
+                this.StartDate = DateTime.Today;
+                if (!this.ContainsParameter(x => x.EndDate))
+                {
+                    this.EndDate = this.StartDate.AddDays(8).AddSeconds(-1);
+                }
+            }
+
             if (this.ContainsParameter(x => x.StartDate) && ! this.ContainsParameter(x => x.EndDate))
             {
                 this.EndDate = this.StartDate.AddDays(7);


### PR DESCRIPTION
If DayOfWeek is specified without a start date/time and/or end date/time, then the StartDate will be 'Today' and the EndDate will be 8 days from today minus 1 second.