### PR TITLE
Refactor log download handling and HTTP client setup

### DIFF
--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Systems/Logs/SaveSonarrLogFileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Systems/Logs/SaveSonarrLogFileCmdlet.cs
@@ -35,7 +35,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Systems.Logs
         public LogFileObject InputObject
         {
             get => null!;
-            set => this.LogUri = value?.ContentsUrl ?? string.Empty;
+            set => this.LogUri = value?.DownloadUrl ?? string.Empty;
         }
 
         [Parameter(Mandatory = true, Position = 0)]
@@ -98,7 +98,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Systems.Logs
             }
 
             this.WriteVerbose($"Writing response to -> {downloadPath}");
-            var response = this.Downloader.DownloadToPathAsync(this.LogUri, downloadPath).GetAwaiter().GetResult();
+            var response = this.Downloader.DownloadToPathAsync(this.LogUri, downloadPath, _creds).GetAwaiter().GetResult();
 
             if (response.IsError)
             {

--- a/src/MG.Sonarr.Next/Models/System/LogFileObject.cs
+++ b/src/MG.Sonarr.Next/Models/System/LogFileObject.cs
@@ -20,6 +20,7 @@ namespace MG.Sonarr.Next.Models.System
         const string UPDATE_PART = "/file/update/";
 
         public string ContentsUrl { get; private set; } = string.Empty;
+        public string DownloadUrl => this.GetStringOrEmpty();
         public DateTimeOffset LastWriteTime { get; private set; }
         public LogFileType Type
         {

--- a/src/MG.Sonarr.Next/Services/Http/Clients/SonarrDownloadClient.cs
+++ b/src/MG.Sonarr.Next/Services/Http/Clients/SonarrDownloadClient.cs
@@ -125,7 +125,6 @@ namespace MG.Sonarr.Next.Services.Http.Clients
                 .ConfigurePrimaryHttpMessageHandler<SonarrClientHandler>()
                 .AddHttpMessageHandler<VerboseHandler>()
                 .AddHttpMessageHandler<DebugSerializeHandler>()
-                .AddHttpMessageHandler<PathHandler>()
                 .AddHttpMessageHandler<AuthHandler>();
 
             return services;


### PR DESCRIPTION
Fixes #106  

---
Updated `SaveSonarrLogFileCmdlet` to use `DownloadUrl` instead of `ContentsUrl` for `LogUri` assignment. Added `_creds` parameter to `Downloader.DownloadToPathAsync` for improved authentication handling.

Introduced a new `DownloadUrl` property in `LogFileObject` to replace `ContentsUrl` in relevant contexts, ensuring a more appropriate URL source for downloads.

Removed `PathHandler` from `SonarrDownloadClient` HTTP pipeline, simplifying the client configuration.