### PR TITLE
81-import sonarrepisodefile

### DIFF
--- a/src/MG.Sonarr.Next.Shell.Bases/Cmdlets/SonarrApiCmdletBase.cs
+++ b/src/MG.Sonarr.Next.Shell.Bases/Cmdlets/SonarrApiCmdletBase.cs
@@ -147,7 +147,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets
         /// <see langword="true"/> if <paramref name="sonarrObj"/> had it properties committed, indicating
         /// a successful operation; otherwise, <see langword="false"/> indicating an error occurred.
         /// </returns>
-        protected bool TryCommitFromResponse<T>(T sonarrObj, in SonarrClientResult response) where T : SonarrObject
+        protected bool TryCommitFromResponse<T>(T sonarrObj, SonarrClientResult response) where T : SonarrObject
         {
             if (response.IsError)
             {

--- a/src/MG.Sonarr.Next.Shell.Bases/Cmdlets/SonarrMetadataCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell.Bases/Cmdlets/SonarrMetadataCmdlet.cs
@@ -56,7 +56,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Bases
             ReadOnlySpan<T> span = list.AsSpan();
             for (int i = span.Length - 1; i >= 0; i--)
             {
-                ref readonly T item = ref span[i];
+                T item = span[i];
                 if (!ids.Contains(item.Id) && !names.IsAnyMatch(item.Name))
                 {
                     list.RemoveAt(i);

--- a/src/MG.Sonarr.Next.Shell.Bases/Extensions/PSCmdletExtensions.cs
+++ b/src/MG.Sonarr.Next.Shell.Bases/Extensions/PSCmdletExtensions.cs
@@ -64,31 +64,30 @@ namespace MG.Sonarr.Next.Shell.Extensions
             return cmdlet.GetUnresolvedProviderPathFromPSPath(path) ?? string.Empty;
         }
 
-        public static bool HasParameter<T>(this T cmdlet, Expression<Func<T, object?>> parameter) where T : PSCmdlet
-        {
-            return parameter.TryGetAsMember(out MemberExpression? memEx)
-                   && 
-                   cmdlet.MyInvocation.BoundParameters.ContainsKey(memEx.Member.Name);
-        }
-        public static bool HasParameter<T>(this T cmdlet, Expression<Func<T, SwitchParameter>> switchExpression, bool onlyIfPresent) where T : PSCmdlet
-        {
-            if (!switchExpression.TryGetAsMember(out MemberExpression? memEx))
-            {
-                return false;
-            }
-            else if (!cmdlet.MyInvocation.BoundParameters.ContainsKey(memEx.Member.Name))
-            {
-                return false;
-            }
-            else if (onlyIfPresent)
-            {
-                return true;
-            }
+        //public static bool HasParameter<T>(this T cmdlet, Expression<Func<T, object?>> parameter) where T : PSCmdlet
+        //{
+        //    return parameter.TryGetAsMember(out MemberExpression? memEx)
+        //           && 
+        //           cmdlet.MyInvocation.BoundParameters.ContainsKey(memEx.Member.Name);
+        //}
+        //public static bool HasParameter<T>(this T cmdlet, Expression<Func<T, SwitchParameter>> switchExpression, bool onlyIfPresent) where T : PSCmdlet
+        //{
+        //    if (!switchExpression.TryGetAsMember(out MemberExpression? memEx))
+        //    {
+        //        return false;
+        //    }
+        //    else if (!cmdlet.MyInvocation.BoundParameters.ContainsKey(memEx.Member.Name))
+        //    {
+        //        return false;
+        //    }
+        //    else if (onlyIfPresent)
+        //    {
+        //        return true;
+        //    }
 
-            var func = switchExpression.Compile();
-            return func(cmdlet).ToBool();
-        }
-
+        //    var func = switchExpression.Compile();
+        //    return func(cmdlet).ToBool();
+        //}
         public static bool HasParameter<TValue>(this PSCmdlet cmdlet, TValue value, [CallerArgumentExpression(nameof(value))] string parameterName = "") where TValue : struct
         {
             return ContainsParameterKey(cmdlet.MyInvocation.BoundParameters, parameterName);
@@ -105,32 +104,6 @@ namespace MG.Sonarr.Next.Shell.Extensions
         public static bool ParameterSetNameIsLike(this PSCmdlet cmdlet, Wildcard wildString)
         {
             return wildString.IsMatch(cmdlet.ParameterSetName);
-        }
-
-        public static void SetValue<TCmdlet, TObj, TValue>(this TCmdlet cmdlet, TValue? value, Expression<Func<TCmdlet, TObj?>> getSetting, Action<TValue, TObj> setValue)
-            where TCmdlet : SonarrCmdletBase
-            where TObj : class, new()
-        {
-            if (value is null)
-            {
-                return;
-            }
-
-
-            //var func = getSetting.Compile();
-            //TObj? obj = func(cmdlet);
-            //if (obj is null)
-            //{
-            //    if (!getSetting.TryGetAsSetter(out IMemberSetter? setter))
-            //    {
-            //        throw new InvalidOperationException("TObj must resolve to a field or property.");
-            //    }
-
-            //    obj = new();
-            //    setter.SetValue(cmdlet, obj);
-            //}
-
-            //setValue.Invoke(value, obj);
         }
         
         public static void WriteCollection<T>(this Cmdlet cmdlet, IEnumerable<T> collection)

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Calendar/GetSonarrCalendarCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Calendar/GetSonarrCalendarCmdlet.cs
@@ -34,7 +34,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Calendar
 
         [Parameter]
         [DistinctValues(typeof(DayOfWeek))]
-        public DayOfWeek[] DayOfWeek { get; set; } = [];
+        public DayOfWeek[]? DayOfWeek { get; set; }
 
         [Parameter, ValidateNotNull, AllowEmptyCollection, ValidateIds(ValidateRangeKind.Positive, NullBehavior = InputNullBehavior.Ignore)]
         public Either<string, int>[] Tags { get; set; } = [];
@@ -77,12 +77,12 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Calendar
 
         protected override void Begin(IServiceProvider provider)
         {
-            if (this.HasParameter(this.Today))
+            if (this.Today)
             {
                 this.StartDate = DateTime.Today;
                 this.EndDate = this.StartDate.AddDays(1).AddSeconds(-1);
             }
-            else if (this.HasParameter(this.Tomorrow))
+            else if (this.Tomorrow)
             {
                 this.StartDate = DateTime.Today.AddDays(1);
                 this.EndDate = this.StartDate.AddDays(1).AddSeconds(-1);
@@ -100,6 +100,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Calendar
             }
         }
 
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming")]
         protected override void Process(IServiceProvider provider)
         {
             this.GetParameters(this.StartDate, this.EndDate.Value, this.IncludeUnmonitored, this.IncludeEpisodeFile, this.IncludeEpisodeImages, this.IncludeSeries);
@@ -111,7 +112,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Calendar
                 this.WriteConditionalError(response.Error);
                 return;
             }
-            else if (this.HasParameter(x => x.DayOfWeek) && this.DayOfWeek.Length > 0)
+            else if (this.HasNotNullParameter(DayOfWeek) && this.DayOfWeek.Length > 0)
             {
                 this.FilterByDayOfWeek(response.Value, this.DayOfWeek);
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Commands/GetSonarrCommandCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Commands/GetSonarrCommandCmdlet.cs
@@ -38,11 +38,15 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Commands
         {
             _ids.UnionWith(this.Id ?? Array.Empty<int>());
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.HasParameter(InputObject) && this.InputObject.Length > 0)
             {
-                _ids.UnionWith(this.InputObject.Select(x => x.Id));
+                foreach (ICommand cmd in this.InputObject)
+                {
+                    _ids.Add(cmd.Id);
+                }
             }
         }
         protected override void End(IServiceProvider provider)

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Commands/GetSonarrCommandHistory.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Commands/GetSonarrCommandHistory.cs
@@ -21,11 +21,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Commands
             var history = provider.GetRequiredService<ICommandHistory>();
 
             IEnumerable<ICommand> commands;
-            if (this.HasParameter(x => x.Refresh, onlyIfPresent: false))
+            if (this.Refresh)
             {
                 commands = this.RefreshUnfinished(provider, history);
             }
-            else if (!this.HasParameter(x => x.All, onlyIfPresent: false))
+            else if (!this.All)
             {
                 commands = history.Where(x => !x.IsCompleted);
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/DownloadClients/RemoveSonarrDownloadClientCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/DownloadClients/RemoveSonarrDownloadClientCmdlet.cs
@@ -15,11 +15,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.DownloadClients
 
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = PSConstants.PSET_EXPLICIT_ID)]
         [ValidateRange(ValidateRangeKind.Positive)]
-        public int[] Id { get; set; } = Array.Empty<int>();
+        public int[] Id { get; set; } = [];
 
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = PSConstants.PSET_PIPELINE)]
         [ValidateIds(ValidateRangeKind.Positive)]
-        public DownloadClientObject[] InputObject { get; set; } = Array.Empty<DownloadClientObject>();
+        public DownloadClientObject[] InputObject { get; set; } = [];
 
         [Parameter]
         public SwitchParameter Force { get; set; }
@@ -39,11 +39,15 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.DownloadClients
         {
             _ids.UnionWith(this.Id);
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.HasParameter(InputObject) && this.InputObject.Length > 0)
             {
-                _ids.UnionWith(this.InputObject.Select(x => x.Id));
+                foreach (DownloadClientObject obj in this.InputObject)
+                {
+                    _ = _ids.Add(obj.Id);
+                }
             }
         }
         protected override void End(IServiceProvider provider)
@@ -56,11 +60,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.DownloadClients
             bool force = this.Force.ToBool();
             foreach (int id in _ids)
             {
-                this.DeleteDownloadClient(id, this.Tag, in force);
+                this.DeleteDownloadClient(id, this.Tag, force);
             }
         }
 
-        private void DeleteDownloadClient(int id, MetadataTag tag, in bool force)
+        private void DeleteDownloadClient(int id, MetadataTag tag, bool force)
         {
             string url = tag.GetUrlForId(id);
             if (!force

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/DownloadClients/UpdateSonarrDownloadClientCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/DownloadClients/UpdateSonarrDownloadClientCmdlet.cs
@@ -36,7 +36,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.DownloadClients
             }
 
             var response = this.SendPutRequest(url, client);
-            _ = this.TryCommitFromResponse(client, in response);
+            _ = this.TryCommitFromResponse(client, response);
         }
     }
 }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/GetSonarrEpisodeCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/GetSonarrEpisodeCmdlet.cs
@@ -46,7 +46,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = BY_SERIES_ID)]
         [Parameter(Mandatory = false, Position = 0, ParameterSetName = BY_SERIES_INPUT)]
         [Alias("SeasonEpId")]
-        public SeasonEpisodeId[] EpisodeIdentifier { get; set; } = [];
+        public SeasonEpisodeId[]? EpisodeIdentifier { get; set; }
 
         protected override MetadataTag GetMetadataTag(IMetadataResolver resolver)
         {
@@ -61,10 +61,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
 
             this.SetReturnables(_epIds, _seriesIds, _params);
         }
-
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Begin(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.EpisodeIdentifier) && !this.EpisodeIdentifier.AreAllValid(out ErrorRecord? error))
+            if (this.HasNotNullParameter(this.EpisodeIdentifier) && this.EpisodeIdentifier.Length > 0 && !this.EpisodeIdentifier.AreAllValid(out ErrorRecord? error))
             {
                 this.WriteError(error);
             }
@@ -91,7 +91,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
                     break;
             }
         }
-
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void End(IServiceProvider provider)
         {
             if (this.InvokeCommand.HasErrors || (_epIds.IsNullOrEmpty() && _seriesIds.IsNullOrEmpty()))
@@ -103,7 +103,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
                 ? this.GetEpisodesById<EpisodeObject>(_epIds!)
                 : this.GetEpisodesBySeries(_seriesIds);
 
-            if (this.HasParameter(x => x.EpisodeIdentifier))
+            if (this.HasNotNullParameter(EpisodeIdentifier) && this.EpisodeIdentifier.Length > 0)
             {
                 episodes = this.EpisodeIdentifier.FilterEpisodes(episodes);
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/RemoveSonarrEpisodeFileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/RemoveSonarrEpisodeFileCmdlet.cs
@@ -17,11 +17,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
 
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ByEpisodeId")]
         [ValidateRange(ValidateRangeKind.Positive)]
-        public int[] Id { get; set; } = Array.Empty<int>();
+        public int[] Id { get; set; } = [];
 
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "ByPipelineInput")]
         [ValidateIds(ValidateRangeKind.Positive, typeof(IEpisodeFilePipeable))]
-        public IEpisodeFilePipeable[] InputObject { get; set; } = Array.Empty<IEpisodeFilePipeable>();
+        public IEpisodeFilePipeable[] InputObject { get; set; } = [];
 
         [Parameter]
         public SwitchParameter Force { get; set; }
@@ -42,9 +42,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
         {
             _ids.UnionWith(this.Id);
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.HasParameter(InputObject) && this.InputObject.Length > 0)
             {
                 _ids.UnionWith(
                     this.InputObject.Select(x => x.EpisodeFileId)

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/UpdateSonarrEpisodeCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/UpdateSonarrEpisodeCmdlet.cs
@@ -31,7 +31,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
 
         private bool IsValid([NotNullWhen(true)] IHasId? value)
         {
-            if (value is null || value.Id <= 0)
+            if (value is null or { Id: <= 0})
             {
                 this.WriteWarning("An episode with an invalid ID was passed. It will be ignored.");
                 return false;
@@ -41,6 +41,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
         }
         private void SendUpdate(EpisodeObject episode)
         {
+            Debug.Assert(episode is not null, "Episode should not be null here.");
             string url = episode.MetadataTag.GetUrlForId(episode.Id);
             if (!this.ShouldProcess(url, "Update Episode"))
             {

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/UpdateSonarrEpisodeCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Episodes/UpdateSonarrEpisodeCmdlet.cs
@@ -49,7 +49,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Episodes
             }
 
             var response = this.SendPutRequest(url, episode);
-            this.TryCommitFromResponse(episode, in response);
+            this.TryCommitFromResponse(episode, response);
         }
     }
 }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/History/GetSonarrHistoryCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/History/GetSonarrHistoryCmdlet.cs
@@ -106,23 +106,23 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.History
 
             this.SetReturnables(_ids, _parameters);
         }
-
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Begin(IServiceProvider provider)
         {
             _ids.UnionWith(this.SeriesId);
 
-            if (this.HasParameter(x => x.IncludeEpisode, onlyIfPresent: true))
+            if (this.IncludeEpisode.IsPresent)
             {
                 _parameters.Add([nameof(this.IncludeEpisode), this.IncludeEpisode.ToBool()]);
             }
 
-            if (this.HasParameter(x => x.IncludeSeries, onlyIfPresent: true))
+            if (this.IncludeSeries.IsPresent)
             {
                 _parameters.Add([nameof(this.IncludeSeries), this.IncludeSeries.ToBool()]);
             }
 
             var clock = provider.GetRequiredService<IClock>();
-            if (this.HasParameter(x => x.Since) && this.Since > clock.Now.DateTime)
+            if (this.HasParameter(Since) && this.Since > clock.Now.DateTime)
             {
                 this.WriteWarning($"The specified parameter '{nameof(this.Since)}' is set to a time in the future. This could give unpredicatable results.");
             }
@@ -132,15 +132,15 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.History
                 this.SetPagingParams();
             }
             
-            if (this.HasParameter(x => x.EventType) && _eventType > -1)
+            if (this.HasParameter(EventType) && _eventType > -1)
             {
                 _parameters.Add(nameof(this.EventType), _eventType, LengthConstants.INT_MAX);
             }
         }
-
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.Series))
+            if (this.Series.Length > 0)
             {
                 _ids.UnionWith(this.Series.Select(x => x.Id));
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Indexers/RemoveSonarrIndexerCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Indexers/RemoveSonarrIndexerCmdlet.cs
@@ -44,7 +44,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Indexers
 
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.InputObject.Length > 0)
             {
                 _ids.UnionWith(this.InputObject.Select(x => x.Id));
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/EditSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/EditSonarrManualImportCmdlet.cs
@@ -58,20 +58,21 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Begin(IServiceProvider provider)
         {
             var edit = provider.GetRequiredService<ManualImportEdit>();
-            if (this.HasParameter(x => x.Episode))
+            if (this.HasParameter(Episode))
             {
                 edit.Episode = this.GetObject(_episode, provider.GetMetadataTag(Meta.EPISODE));
             }
 
-            if (this.HasParameter(x => x.Quality))
+            if (this.HasParameter(Quality))
             {
                 edit.Quality = this.GetQualityRevision(_quality, provider.GetMetadataTag(Meta.QUALITY));
             }
 
-            if (this.HasParameter(x => x.Series))
+            if (this.HasParameter(Series))
             {
                 edit.Series = this.GetObject(_series, provider.GetMetadataTag(Meta.SERIES));
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/GetSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/GetSonarrManualImportCmdlet.cs
@@ -11,6 +11,7 @@ using IOPath = System.IO.Path;
 namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
 {
     [Cmdlet(VerbsCommon.Get, "SonarrManualImport", DefaultParameterSetName = BY_FOLDER)]
+    //[OutputType(typeof())]
     public sealed class GetSonarrManualImportCmdlet : SonarrApiCmdletBase
     {
         const string BY_FOLDER = "ByFolderPath";

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
@@ -1,0 +1,68 @@
+﻿using MG.Sonarr.Next.Extensions;
+using MG.Sonarr.Next.Metadata;
+using MG.Sonarr.Next.Models.ManualImports;
+using MG.Sonarr.Next.Services.Http;
+using MG.Sonarr.Next.Shell.Cmdlets.Bases;
+using MG.Sonarr.Next.Shell.Exceptions;
+using MG.Sonarr.Next.Shell.Extensions;
+using System.Collections.Immutable;
+
+namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
+{
+    [Cmdlet(VerbsLifecycle.Invoke, "SonarrManualImport", ConfirmImpact = ConfirmImpact.Low, SupportsShouldProcess = true)]
+    public class InvokeSonarrManualImportCmdlet : SonarrMetadataCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true), AllowEmptyCollection]
+        public ManualImportObject[] InputObject { get; set; } = [];
+
+        private MetadataList<ManualImportObject> _list = null!;
+        protected override MetadataTag GetMetadataTag(IMetadataResolver resolver)
+        {
+            return resolver[Meta.MANUAL_IMPORT];
+        }
+
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in nameof()")]
+        protected override void Process(IServiceProvider provider)
+        {
+            if (this.InputObject.Length == 0)
+                return;
+
+
+            foreach (ManualImportObject obj in this.InputObject)
+            {
+                if (!obj.IsReadyToPost())
+                {
+                    this.WriteError(new ErrorRecord(new SonarrParameterException(nameof(InputObject), ParameterErrorType.Malformed, "The import is not ready to post as it's missing properties."), 
+                        "InvokeSonarrManualImport:ImportNotReady", ErrorCategory.InvalidArgument, obj));
+
+                    continue;
+                }
+
+                if (this.ShouldProcess(this.Tag.UrlBase, $"Manual Import to Series '{obj.Series?.Title}' as episode number {obj.Episodes?.FirstOrDefault()?.AbsoluteEpisodeNumber}"))
+                {
+                    _list ??= new(1);
+                    _list.Add(obj);
+                }
+            }
+        }
+
+        protected override void End(IServiceProvider provider)
+        {
+            if (_list is null or { Count: 0 })
+                return;
+
+            SonarrClientResult response = this.SendPostRequest(this.Tag.UrlBase, _list.ToImmutableArray());
+            if (response.IsError)
+            {
+                this.WriteConditionalError(response.Error);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _list?.Clear();
+            _list = null!;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
@@ -1,16 +1,8 @@
-﻿using MG.Sonarr.Next.Extensions;
-using MG.Sonarr.Next.Extensions.PSO;
-using MG.Sonarr.Next.Metadata;
-using MG.Sonarr.Next.Models;
+﻿using MG.Sonarr.Next.Metadata;
 using MG.Sonarr.Next.Models.ManualImports;
-using MG.Sonarr.Next.Models.Profiles;
-using MG.Sonarr.Next.Models.Qualities;
-using MG.Sonarr.Next.Models.Series;
 using MG.Sonarr.Next.Services.Http;
 using MG.Sonarr.Next.Shell.Cmdlets.Bases;
 using MG.Sonarr.Next.Shell.Exceptions;
-using MG.Sonarr.Next.Shell.Extensions;
-using System.Collections.Immutable;
 
 namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
 {
@@ -19,6 +11,9 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true), AllowEmptyCollection]
         public ManualImportObject[] InputObject { get; set; } = [];
+
+        [Parameter]
+        public ManualImportMode ImportMode { get; set; } = ManualImportMode.Copy;
 
         private MetadataList<ManualImportObject> _list = null!;
         protected override MetadataTag GetMetadataTag(IMetadataResolver resolver)
@@ -57,18 +52,8 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
 
             var body = new
             {
-                Files = _list.Select(x => new
-                {
-                    Path = x.GetValue<string>("Path"),
-                    SeriesId = x.Series!.Id,
-                    EpisodeIds = x.Episodes.Select(e => e.Id).ToArray(),
-                    Quality = x.Quality.ToDictionary(nameof(QualityRevisionObject.MetadataTag)),
-                    Languages = x.GetValue<PSObject[]>("Languages")?.Select(x => x.ToDictionary(nameof(LanguageProfileObject.MetadataTag))).ToArray() ?? [],
-                    ReleaseGroup = x.GetValue<string>("ReleaseGroup"),
-                    IndexerFlags = x.GetValue<int>("IndexerFlags"),
-                    ReleaseType = x.GetValue<int>("ReleaseType")
-                }).ToArray(),
-                ImportMode = "copy",
+                Files = _list.ToManualImportFiles(),
+                ImportMode = GetImportModeString(this.ImportMode),
                 Name = "ManualImport",
             };
 
@@ -87,5 +72,21 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
             _list = null!;
             base.Dispose(disposing);
         }
+
+        private static string GetImportModeString(ManualImportMode mode)
+        {
+            return mode switch
+            {
+                ManualImportMode.Copy => "copy",
+                ManualImportMode.Move => "move",
+                _ => string.Empty,
+            };
+        }
+    }
+
+    public enum ManualImportMode
+    {
+        Copy,
+        Move,
     }
 }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
@@ -1,4 +1,5 @@
-﻿using MG.Sonarr.Next.Metadata;
+﻿using MG.Sonarr.Next.Attributes;
+using MG.Sonarr.Next.Metadata;
 using MG.Sonarr.Next.Models.ManualImports;
 using MG.Sonarr.Next.Services.Http;
 using MG.Sonarr.Next.Shell.Cmdlets.Bases;
@@ -7,6 +8,7 @@ using MG.Sonarr.Next.Shell.Exceptions;
 namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
 {
     [Cmdlet(VerbsLifecycle.Invoke, "SonarrManualImport", ConfirmImpact = ConfirmImpact.Low, SupportsShouldProcess = true)]
+    [MetadataCanPipe(Tag = Meta.MANUAL_IMPORT)]
     public class InvokeSonarrManualImportCmdlet : SonarrMetadataCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true), AllowEmptyCollection]

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
@@ -3,6 +3,9 @@ using MG.Sonarr.Next.Extensions.PSO;
 using MG.Sonarr.Next.Metadata;
 using MG.Sonarr.Next.Models;
 using MG.Sonarr.Next.Models.ManualImports;
+using MG.Sonarr.Next.Models.Profiles;
+using MG.Sonarr.Next.Models.Qualities;
+using MG.Sonarr.Next.Models.Series;
 using MG.Sonarr.Next.Services.Http;
 using MG.Sonarr.Next.Shell.Cmdlets.Bases;
 using MG.Sonarr.Next.Shell.Exceptions;
@@ -20,7 +23,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
         private MetadataList<ManualImportObject> _list = null!;
         protected override MetadataTag GetMetadataTag(IMetadataResolver resolver)
         {
-            return resolver[Meta.MANUAL_IMPORT];
+            return resolver[Meta.COMMAND];
         }
 
         [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in nameof()")]
@@ -28,7 +31,6 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
         {
             if (this.InputObject.Length == 0)
                 return;
-
 
             foreach (ManualImportObject obj in this.InputObject)
             {
@@ -53,10 +55,26 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
             if (_list is null or { Count: 0 })
                 return;
 
-            Dictionary<string, object?>[] array = [.. _list.Select(x => x.ToDictionary(nameof(SonarrObject.MetadataTag)))];
-            this.SerializeIfDebug(array, includeType: false);
+            var body = new
+            {
+                Files = _list.Select(x => new
+                {
+                    Path = x.GetValue<string>("Path"),
+                    SeriesId = x.Series!.Id,
+                    EpisodeIds = x.Episodes.Select(e => e.Id).ToArray(),
+                    Quality = x.Quality.ToDictionary(nameof(QualityRevisionObject.MetadataTag)),
+                    Languages = x.GetValue<PSObject[]>("Languages")?.Select(x => x.ToDictionary(nameof(LanguageProfileObject.MetadataTag))).ToArray() ?? [],
+                    ReleaseGroup = x.GetValue<string>("ReleaseGroup"),
+                    IndexerFlags = x.GetValue<int>("IndexerFlags"),
+                    ReleaseType = x.GetValue<int>("ReleaseType")
+                }).ToArray(),
+                ImportMode = "copy",
+                Name = "ManualImport",
+            };
 
-            SonarrClientResult response = this.SendPostRequest(this.Tag.UrlBase, array);
+            this.SerializeIfDebug(body, includeType: false);
+
+            SonarrClientResult response = this.SendPostRequest(this.Tag.UrlBase, body);
             if (response.IsError)
             {
                 this.WriteConditionalError(response.Error);

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/ManualImports/InvokeSonarrManualImportCmdlet.cs
@@ -1,5 +1,7 @@
 ﻿using MG.Sonarr.Next.Extensions;
+using MG.Sonarr.Next.Extensions.PSO;
 using MG.Sonarr.Next.Metadata;
+using MG.Sonarr.Next.Models;
 using MG.Sonarr.Next.Models.ManualImports;
 using MG.Sonarr.Next.Services.Http;
 using MG.Sonarr.Next.Shell.Cmdlets.Bases;
@@ -51,7 +53,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.ManualImports
             if (_list is null or { Count: 0 })
                 return;
 
-            SonarrClientResult response = this.SendPostRequest(this.Tag.UrlBase, _list.ToImmutableArray());
+            Dictionary<string, object?>[] array = [.. _list.Select(x => x.ToDictionary(nameof(SonarrObject.MetadataTag)))];
+            this.SerializeIfDebug(array, includeType: false);
+
+            SonarrClientResult response = this.SendPostRequest(this.Tag.UrlBase, array);
             if (response.IsError)
             {
                 this.WriteConditionalError(response.Error);

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/NamingConfig/UpdateSonarrNamingConfigCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/NamingConfig/UpdateSonarrNamingConfigCmdlet.cs
@@ -23,7 +23,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.NamingConfig
             }
 
             var response = this.SendPutRequest(url, this.InputObject);
-            bool committed = this.TryCommitFromResponse(this.InputObject, in response);
+            bool committed = this.TryCommitFromResponse(this.InputObject, response);
             Debug.Assert(committed);
         }
     }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Delay/RemoveSonarrDelayProfileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Delay/RemoveSonarrDelayProfileCmdlet.cs
@@ -17,11 +17,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Delay
 
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = PSConstants.PSET_EXPLICIT_ID)]
         [ValidateRange(2, int.MaxValue)]
-        public int[] Id { get; set; } = Array.Empty<int>();
+        public int[] Id { get; set; } = [];
 
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = PSConstants.PSET_PIPELINE)]
         [ValidateIds(ValidateRangeKind.Positive)]
-        public DelayProfileObject[] InputObject { get; set; } = Array.Empty<DelayProfileObject>();
+        public DelayProfileObject[] InputObject { get; set; } = [];
 
         [Parameter]
         public SwitchParameter Force { get; set; }
@@ -41,9 +41,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Delay
         {
             _ids.UnionWith(this.Id);
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject) && this.InputObject.Length > 0)
+            if (this.InputObject.Length > 0)
             {
                 _ids.UnionWith(this.InputObject.Select(x => x.Id));
             }
@@ -64,11 +65,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Delay
             bool force = this.Force.ToBool();
             foreach (int id in _ids)
             {
-                this.DeleteProfile(in id, this.Tag, in force);
+                this.DeleteProfile(in id, this.Tag, force);
             }
         }
 
-        private void DeleteProfile(in int id, MetadataTag tag, in bool force)
+        private void DeleteProfile(in int id, MetadataTag tag, bool force)
         {
             string url = tag.GetUrlForId(id);
             if (!force

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Delay/UpdateSonarrDelayProfileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Delay/UpdateSonarrDelayProfileCmdlet.cs
@@ -36,7 +36,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Delay
             }
 
             var response = this.SendPutRequest(url, profile);
-            _ = this.TryCommitFromResponse(profile, in response);
+            _ = this.TryCommitFromResponse(profile, response);
         }
     }
 }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Languages/GetSonarrLanguageProfileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Languages/GetSonarrLanguageProfileCmdlet.cs
@@ -1,5 +1,6 @@
 ﻿using MG.Sonarr.Next.Attributes;
 using MG.Sonarr.Next.Collections;
+using MG.Sonarr.Next.Extensions;
 using MG.Sonarr.Next.Metadata;
 using MG.Sonarr.Next.Models.Profiles;
 using MG.Sonarr.Next.Shell.Attributes;
@@ -24,7 +25,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Languages
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = PSConstants.PSET_PIPELINE, DontShow = true)]
         [ValidateIds(ValidateRangeKind.Positive, typeof(ILanguageProfilePipeable))]
-        public ILanguageProfilePipeable[] InputObject { get; set; } = Array.Empty<ILanguageProfilePipeable>();
+        public ILanguageProfilePipeable[] InputObject { get; set; } = [];
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [Parameter(Mandatory = false, Position = 0)]
@@ -54,11 +55,12 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Languages
                 _wcNames.UnionWith(this.Name);
             }
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.InputObject.Length > 0)
             {
-                _ids.UnionWith(this.InputObject.Select(x => x.LanguageProfileId));
+                _ids.AddRange(this.InputObject);
             }
         }
         protected override void End(IServiceProvider provider)
@@ -80,8 +82,8 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Languages
 
         private MetadataList<LanguageProfileObject> GetByName(WildcardSet names, SortedSet<int> ids)
         {
-            var response = this.GetAll<LanguageProfileObject>();
-            if (response.Count <= 0 || names.Count <= 0)
+            MetadataList<LanguageProfileObject> response = this.GetAll<LanguageProfileObject>();
+            if (response.Count == 0 || names.Count == 0)
             {
                 return response;
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Qualities/GetSonarrQualityProfileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Qualities/GetSonarrQualityProfileCmdlet.cs
@@ -21,7 +21,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Qualities
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [Parameter(Mandatory = true, ParameterSetName = PSConstants.PSET_PIPELINE, ValueFromPipeline = true)]
         [ValidateIds(ValidateRangeKind.Positive, typeof(IQualityProfilePipeable))]
-        public IQualityProfilePipeable[] InputObject { get; set; } = Array.Empty<IQualityProfilePipeable>();
+        public IQualityProfilePipeable[] InputObject { get; set; } = [];
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [Parameter(Mandatory = true, ParameterSetName = PSConstants.PSET_EXPLICIT_ID)]
@@ -47,20 +47,18 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Qualities
             return resolver[Meta.QUALITY_PROFILE];
         }
 
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Begin(IServiceProvider provider)
         {
             _ids.UnionWith(this.Id);
-            if (this.HasParameter(x => x.Name))
+            if (this.Name.Length > 0)
             {
-                if (this.HasParameter(this.Name))
-                {
-                    this.Name.SplitToSets(_ids, _wcNames, !this.MyInvocation.IsBoundPositionally(_namePropertyName));
-                }
+                this.Name.SplitToSets(_ids, _wcNames, !this.MyInvocation.IsBoundPositionally(_namePropertyName));
             }
         }
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.InputObject.Length > 0)
             {
                 _ids.UnionWith(
                     this.InputObject.Where(x => x.QualityProfileId > 0).Select(x => x.QualityProfileId));

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Releases/UpdateSonarrReleaseProfileCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Profiles/Releases/UpdateSonarrReleaseProfileCmdlet.cs
@@ -36,7 +36,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Profiles.Releases
             }
 
             var response = this.SendPutRequest(url, profile);
-            _ = this.TryCommitFromResponse(profile, in response);
+            _ = this.TryCommitFromResponse(profile, response);
         }
     }
 }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/RootFolders/RemoveSonarrRootFolderCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/RootFolders/RemoveSonarrRootFolderCmdlet.cs
@@ -16,11 +16,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.RootFolders
 
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = PSConstants.PSET_PIPELINE)]
         [ValidateIds(ValidateRangeKind.Positive)]
-        public RootFolderObject[] InputObject { get; set; } = Array.Empty<RootFolderObject>();
+        public RootFolderObject[] InputObject { get; set; } = [];
 
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = PSConstants.PSET_EXPLICIT_ID)]
         [ValidateRange(ValidateRangeKind.Positive)]
-        public int[] Id { get; set; } = Array.Empty<int>();
+        public int[] Id { get; set; } = [];
 
         [Parameter]
         public SwitchParameter Force { get; set; }
@@ -41,9 +41,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.RootFolders
         {
             _ids.UnionWith(this.Id);
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            if (!this.HasParameter(x => x.InputObject))
+            if (!this.HasParameter(InputObject))
             {
                 return;
             }
@@ -69,11 +70,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.RootFolders
 
             foreach (int id in _ids)
             {
-                this.PerformDelete(in id, in force);
+                this.PerformDelete(id, force);
             }
         }
 
-        private void PerformDelete(in int id, in bool force)
+        private void PerformDelete(int id, bool force)
         {
             string url = this.Tag.GetUrlForId(id);
 

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Series/AddSonarrSeriesCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Series/AddSonarrSeriesCmdlet.cs
@@ -15,30 +15,15 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
     [MetadataCanPipe(Tag = Meta.SERIES_ADD)]
     public sealed class AddSonarrSeriesCmdlet : SonarrApiCmdletBase//, IDynamicParameters
     {
-        List<AddSeriesObject> _list = null!;
-        Range _range;
         private EditableSeriesAddOptions? _addOptions;
         private SeriesAddOptions? _usingOptions;
         internal SeriesAddOptions AddOptions => _usingOptions ??= _addOptions ?? SeriesAddOptions.Default;
-        MetadataTag Tag { get; set; } = null!;
+        private MetadataTag Tag { get; set; } = null!;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [Parameter(Mandatory = true, ValueFromPipeline = true)]
         [ValidateNotNull]
-        public AddSeriesObject[] InputObject
-        {
-            get => [];
-            set
-            {
-                value ??= [];
-                _list ??= new(value.Length);
-                int count = _list.Count;
-                int howMany = value.Length;
-                _range = new Range(count, howMany);
-
-                _list.AddRange(value);
-            }
-        }
+        public AddSeriesObject[] InputObject { get; set; } = [];
 
         [Parameter(Mandatory = true, ParameterSetName = "AbsolutePath")]
         [ValidateNotNullOrWhiteSpace]
@@ -59,7 +44,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
         [System.Management.Automation.AllowNull]
         [AllowEmptyCollection]
         [DistinctValues(typeof(SeriesAddIgnoreAction))]
-        public SeriesAddIgnoreAction[] SearchForMissingEpisodes { get; set; } = [];
+        public SeriesAddIgnoreAction[]? SearchForMissingEpisodes { get; set; }
 
         [Parameter(Mandatory = false)]
         public string SeriesType { get; set; } = string.Empty;
@@ -67,59 +52,15 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
         [Parameter(Mandatory = false)]
         public SwitchParameter UseSeasonFolders { get; set; }
 
-        //const string WITH_FILES = "SearchEpisodesWithFiles";
-        //const string WITHOUT_FILES = "SearchEpisodesWithoutFiles";
-        //static readonly Lazy<RuntimeDefinedParameterDictionary> _runtimeDic = new(CreateRuntimeDictionary);
-        //public object? GetDynamicParameters()
-        //{
-        //    RuntimeDefinedParameterDictionary? dict = null;
-        //    if (this.SearchForMissingEpisodes)
-        //    {
-        //        dict = _runtimeDic.Value;
-        //    }
-
-        //    return dict;
-        //}
-
-        //private static RuntimeDefinedParameterDictionary CreateRuntimeDictionary()
-        //{
-        //    return new RuntimeDefinedParameterDictionary
-        //        {
-        //            {
-        //                WITH_FILES,
-        //                new RuntimeDefinedParameter()
-        //                {
-        //                    Attributes =
-        //                    {
-        //                        new ParameterAttribute() { Mandatory = false },
-        //                    },
-        //                    Name = WITH_FILES,
-        //                    ParameterType = typeof(SwitchParameter),
-        //                }
-        //            },
-        //            {
-        //                WITHOUT_FILES,
-        //                new RuntimeDefinedParameter()
-        //                {
-        //                    Attributes =
-        //                    {
-        //                        new ParameterAttribute() { Mandatory = false },
-        //                    },
-        //                    Name = WITHOUT_FILES,
-        //                    ParameterType = typeof(SwitchParameter),
-        //                }
-        //            }
-        //        };
-        //}
-
         protected override void OnCreatingScope(IServiceProvider provider)
         {
             base.OnCreatingScope(provider);
             this.Tag = provider.GetRequiredService<IMetadataResolver>()[Meta.SERIES];
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Begin(IServiceProvider provider)
         {
-            if (this.HasParameter(this.SearchForMissingEpisodes) && this.SearchForMissingEpisodes.Length > 0)
+            if (this.HasNotNullParameter(SearchForMissingEpisodes) && this.SearchForMissingEpisodes.Length > 0)
             {
                 int actions = this.SearchForMissingEpisodes.Distinct().Sum(x => (int)x);
 
@@ -151,26 +92,27 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
             }
         }
 
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         private void SetPropertiesFromParameters(AddSeriesObject pso, SeriesAddOptions options)
         {
             pso.AddOptions = options;
 
-            if (this.HasParameter(x => x.UseSeasonFolders, onlyIfPresent: true))
+            if (this.UseSeasonFolders.IsPresent)
             {
                 pso.UseSeasonFolders = this.UseSeasonFolders.ToBool();
             }
 
-            if (this.HasParameter(this.QualityProfileId))
+            if (this.HasParameter(QualityProfileId))
             {
                 pso.QualityProfileId = this.QualityProfileId;
             }
 
-            if (this.HasParameter(this.SeriesType))
+            if (this.HasParameter(SeriesType))
             {
                 pso.SeriesType = this.SeriesType;
             }
 
-            if (this.HasParameter(x => x.IsMonitored, onlyIfPresent: true))
+            if (this.IsMonitored.IsPresent)
             {
                 pso.IsMonitored = this.IsMonitored.ToBool();
             }

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Series/GetSonarrSeriesCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Series/GetSonarrSeriesCmdlet.cs
@@ -10,6 +10,8 @@ using MG.Sonarr.Next.Shell.Output;
 using MG.Sonarr.Next.Shell.Attributes;
 using MG.Sonarr.Next.Collections;
 using MG.Sonarr.Next.Unions;
+using MG.Sonarr.Next.Extensions;
+using System.Runtime.InteropServices;
 
 namespace MG.Sonarr.Next.Shell.Cmdlets.Series
 {
@@ -60,9 +62,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
         }
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(this.InputObject))
+            if (this.InputObject.Length > 0)
             {
-                _ids.UnionWith(this.InputObject.Select(x => x.SeriesId));
+                _ids.AddRange(this.InputObject);
+                //_ids.UnionWith(this.InputObject.Select(x => x.SeriesId));
             }
             else
             {
@@ -73,21 +76,12 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
             if (_ids.Count > 0)
             {
                 hadIds = true;
-                foreach (var result in this.GetSeriesById<SeriesObject>(_ids))
-                {
-                    if (result.IsError)
-                    {
-                        this.WriteConditionalError(result.Error);
-                        continue;
-                    }
-
-                    this.WriteObject(result.Value);
-                }
+                this.WriteSeriesById(_ids);
             }
 
             if (_wcNames.Count > 0)
             {
-                var response = this.GetSeriesByName<SeriesObject>(_wcNames);
+                var response = this.GetSeriesByName(_wcNames);
                 if (response.IsError)
                 {
                     this.StopCmdlet(response.Error);
@@ -109,10 +103,9 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
             }
         }
 
-        private SonarrClientResult<MetadataList<T>> GetSeriesByName<T>(WildcardSet names)
-            where T : PSObject, IComparable<T>, IJsonMetadataTaggable
+        private SonarrClientResult<MetadataList<SeriesObject>> GetSeriesByName(WildcardSet names)
         {
-            var result = this.GetAllSeries<T>();
+            var result = this.GetAllSeries<SeriesObject>();
             if (result.IsError)
             {
                 return result;
@@ -123,7 +116,9 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
                 PSObject item = result.Value[i];
                 if (!item.TryGetProperty(Constants.TITLE, out string? title)
                     ||
-                    !names.IsAnyMatch(title.AsSpan()))
+                    title is null
+                    ||
+                    !names.IsAnyMatch(title))
                 {
                     result.Value.RemoveAt(i);
                 }
@@ -136,18 +131,18 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
         {
             return this.SendGetRequest<MetadataList<T>>(this.Tag.UrlBase);
         }
-        private IEnumerable<SonarrClientResult<T>> GetSeriesById<T>(IEnumerable<int> ids) where T : PSObject, IJsonMetadataTaggable
+        private void WriteSeriesById(SortedSet<int> ids)
         {
             foreach (int id in ids)
             {
-                var result = this.SendGetRequest<T>(this.Tag.GetUrlForId(id));
+                SonarrClientResult<SeriesObject> result = this.SendGetRequest<SeriesObject>(this.Tag.GetUrlForId(id));
                 if (result.IsError)
                 {
                     this.WriteConditionalError(result.Error);
                     continue;
                 }
 
-                yield return result;
+                this.WriteObject(result.Value);
             }
         }
 

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Series/SearchSonarrSeriesCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Series/SearchSonarrSeriesCmdlet.cs
@@ -32,9 +32,10 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Series
             base.OnCreatingScope(provider);
             _tag = provider.GetRequiredService<IMetadataResolver>()[Meta.SERIES_ADD];
         }
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Process(IServiceProvider provider)
         {
-            string path = this.HasParameter(x => x.Name)
+            string path = this.HasParameter(Name)
                 ? GetSearchByNamePath(_wildcardStr)
                 : string.Format(SEARCH_ID_QUERY, this.TVDbId);
 

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Tags/AddSonarrTagCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Tags/AddSonarrTagCmdlet.cs
@@ -61,13 +61,14 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
             return resolver[Meta.TAG];
         }
 
+        [SuppressMessage("Style", "IDE0009:Member access should be qualified.", Justification = "Used in implicit naming.")]
         protected override void Begin(IServiceProvider provider)
         {
-            if (this.HasParameter(this.Id))
+            if (this.Id.Length > 0)
             {
                 _ids.UnionWith(this.Id);
             }
-            else if (this.HasParameter(this.Name))
+            else if (this.Name.Length > 0)
             {
                 this.Name.SplitToSets(_ids, _wcNames, !this.MyInvocation.IsBoundPositionally(_namePropertyName));
             }
@@ -76,7 +77,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
             {
                 var all = this.GetAll<TagObject>();
 
-                foreach (var tag in all)
+                foreach (TagObject tag in all)
                 {
                     if (_wcNames.IsAnyMatch(tag.Label))
                     {
@@ -87,7 +88,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
         }
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.InputObject.Length > 0)
             {
                 this.AddUrlsFromMetadata(this.InputObject);
             }
@@ -113,7 +114,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
                         "Adding tags: ({0})",
                         string.Join(", ", _ids.Where(x => !kvp.Value.Tags.Contains(x))))))
                 {
-                    if (!this.PerformTagUpdate(in kvp))
+                    if (!this.PerformTagUpdate(kvp))
                     {
                         continue;
                     }
@@ -121,7 +122,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
             }
         }
 
-        private bool PerformTagUpdate(in KeyValuePair<string, ITagPipeable> kvp)
+        private bool PerformTagUpdate(KeyValuePair<string, ITagPipeable> kvp)
         {
             kvp.Value.Tags.UnionWith(_ids);
 

--- a/src/MG.Sonarr.Next.Shell/Cmdlets/Tags/ClearSonarrTagCmdlet.cs
+++ b/src/MG.Sonarr.Next.Shell/Cmdlets/Tags/ClearSonarrTagCmdlet.cs
@@ -69,11 +69,11 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
 
         protected override void Begin(IServiceProvider provider)
         {
-            if (this.HasParameter(this.Id))
+            if (this.Id.Length > 0)
             {
                 _ids.UnionWith(this.Id);
             }
-            else if (this.HasParameter(this.Name))
+            else if (this.Name.Length > 0)
             {
                 this.Name.SplitToSets(_ids, _wcNames, !this.MyInvocation.IsBoundPositionally(_namePropertyName));
             }
@@ -93,7 +93,7 @@ namespace MG.Sonarr.Next.Shell.Cmdlets.Tags
         }
         protected override void Process(IServiceProvider provider)
         {
-            if (this.HasParameter(x => x.InputObject))
+            if (this.InputObject.Length > 0)
             {
                 AddUrlsFromMetadata(this.InputObject, _updates);
             }

--- a/src/MG.Sonarr.Next.Shell/MG.Sonarr.Next.Shell.csproj
+++ b/src/MG.Sonarr.Next.Shell/MG.Sonarr.Next.Shell.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-	<LangVersion>latest</LangVersion>
+	<LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<Version>2.0.0</Version>

--- a/src/MG.Sonarr.Next/Collections/WildcardSet.cs
+++ b/src/MG.Sonarr.Next/Collections/WildcardSet.cs
@@ -1,7 +1,9 @@
 ﻿using MG.Sonarr.Next.Collections.Pools;
 using MG.Sonarr.Next.Strings;
+using System.Buffers;
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace MG.Sonarr.Next.Collections;
 
@@ -159,13 +161,25 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
     /// </returns>
     public bool IsAnyMatch(ReadOnlySpan<char> value)
     {
-        foreach (Wildcard wc in _set)
+        int count = _set.Count;
+        Wildcard[] array = ArrayPool<Wildcard>.Shared.Rent(count);
+        try
         {
-            if (wc.IsMatch(value))
-                return true;
-        }
+            _set.CopyTo(array);
+            ref Wildcard first = ref MemoryMarshal.GetArrayDataReference(array);
 
-        return false;
+            for (int i = 0; i < count; i++)
+            {
+                if (Unsafe.Add(ref first, i).IsMatch(value))
+                    return true;
+            }
+
+            return false;
+        }
+        finally
+        {
+            ArrayPool<Wildcard>.Shared.Return(array);
+        }
     }
 
     /// <summary>
@@ -178,7 +192,14 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
     /// </returns>
     public bool IsAnyMatch([DisallowNull] string value)
     {
-        return _set.Any(ws => ws.IsMatch(value));
+        ReadOnlySpan<char> chars = value;
+        foreach (Wildcard str in _set)
+        {
+            if (str.IsMatch(chars, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     public bool Remove(Wildcard value)
@@ -193,7 +214,14 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
     /// <param name="other">The collection to compare to the current <see cref="WildcardSet"/> object.</param>
     public void UnionWith(IEnumerable<Wildcard> other)
     {
-        _set.UnionWith(other);
+        if (other is WildcardSet wcSet)
+        {
+            _set.UnionWith(wcSet._set);
+        }
+        else
+        {
+            _set.UnionWith(other);
+        }
     }
 
     /// <summary>
@@ -203,18 +231,29 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
     /// <param name="other">The collection of string patterns to compare to the current <see cref="WildcardSet"/> object.</param>
     public void UnionWith(IEnumerable<string> other)
     {
-        this.UnionWith(other.Select(Wildcard.Parse));
+        foreach (string s in other)
+        {
+            if (s is null) continue;
+
+            _ = _set.Add(s);
+        }
     }
 
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="WildcardSet"/>.
     /// </summary>
     [DebuggerStepThrough]
-    public IEnumerator<Wildcard> GetEnumerator()
+    public Enumerator GetEnumerator()
     {
-        return _set.GetEnumerator();
+        return new(_set);
     }
 
+    /// <inheritdoc/>
+    [DebuggerStepThrough]
+    IEnumerator<Wildcard> IEnumerable<Wildcard>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
     /// <inheritdoc/>
     [DebuggerStepThrough]
     IEnumerator IEnumerable.GetEnumerator()
@@ -241,39 +280,65 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
             : new();
     }
 
-    private sealed class WildcardEqualityComparer : IEqualityComparer<Wildcard>
-#if NET9_0_OR_GREATER
-        , IAlternateEqualityComparer<ReadOnlySpan<char>, Wildcard>
-#endif
+    [StructLayout(LayoutKind.Auto)]
+    public struct Enumerator : IEnumerator<Wildcard>
     {
-        /// <summary>
-        /// Determines whether the specified wildcards are equal.
-        /// </summary>
-        /// <param name="x">The first wildcard to compare.</param>
-        /// <param name="y">The second wildcard to compare.</param>
-        /// <returns><see langword="true"/> if the specified wildcards are equal; otherwise, <see langword="false"/>.</returns>
-        public bool Equals(Wildcard x, Wildcard y)
+        private HashSet<Wildcard> _set;
+        private HashSet<Wildcard>.Enumerator _enumerator;
+        private Wildcard _current;
+
+        internal Enumerator(HashSet<Wildcard> set)
         {
-            return x.Equals(y);
+            _set = set;
+            _enumerator = set.GetEnumerator();
+            _current = default;
         }
 
-        /// <summary>
-        /// Returns a hash code for the specified wildcard.
-        /// </summary>
-        /// <param name="obj">The wildcard for which a hash code is to be returned.</param>
-        /// <returns>A hash code for the specified wildcard.</returns>
-        public int GetHashCode([DisallowNull] Wildcard obj)
+        public readonly Wildcard Current => _current;
+        readonly object? IEnumerator.Current => this.Current;
+
+        public void Dispose()
         {
-            return obj.GetHashCode();
+            this = default;
         }
 
-#if NET9_0_OR_GREATER
+        public bool MoveNext()
+        {
+            if (_enumerator.MoveNext())
+            {
+                _current = _enumerator.Current;
+                return true;
+            }
+
+            return false;
+        }
+
+        void IEnumerator.Reset()
+        {
+            var enumerator = _enumerator;
+            ((IEnumerator)enumerator).Reset();
+            _enumerator = enumerator;
+        }
+    }
+
+    private sealed class WildcardEqualityComparer : IEqualityComparer<Wildcard>, IAlternateEqualityComparer<ReadOnlySpan<char>, Wildcard>,
+        IAlternateEqualityComparer<string, Wildcard>
+    {
         /// <summary>
         /// Creates a wildcard from the specified read-only span of characters.
         /// </summary>
         /// <param name="alternate">The read-only span of characters to create the wildcard from.</param>
         /// <returns>A new wildcard created from the specified span.</returns>
         public Wildcard Create(ReadOnlySpan<char> alternate)
+        {
+            return Wildcard.Parse(alternate);
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="alternate"></param>
+        /// <returns></returns>
+        public Wildcard Create(string alternate)
         {
             return Wildcard.Parse(alternate);
         }
@@ -286,7 +351,22 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
         /// <returns><see langword="true"/> if the specified span and wildcard are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(ReadOnlySpan<char> alternate, Wildcard other)
         {
-            return other.Equals(alternate);
+            return other.Equals(alternate, StringComparison.OrdinalIgnoreCase);
+        }
+        ///
+        public bool Equals(string alternate, Wildcard other)
+        {
+            return other.Equals(alternate, StringComparison.OrdinalIgnoreCase);
+        }
+        /// <summary>
+        /// Determines whether the specified wildcards are equal.
+        /// </summary>
+        /// <param name="x">The first wildcard to compare.</param>
+        /// <param name="y">The second wildcard to compare.</param>
+        /// <returns><see langword="true"/> if the specified wildcards are equal; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(Wildcard x, Wildcard y)
+        {
+            return x.Equals(y);
         }
 
         /// <summary>
@@ -296,9 +376,21 @@ public sealed class WildcardSet : IReadOnlyCollection<Wildcard>, IResettable
         /// <returns>A hash code for the specified span.</returns>
         public int GetHashCode(ReadOnlySpan<char> alternate)
         {
-            return ((IAlternateEqualityComparer<ReadOnlySpan<char>, string>)StringComparer.OrdinalIgnoreCase)
-                .GetHashCode(alternate);
+            return string.GetHashCode(alternate, StringComparison.OrdinalIgnoreCase);
         }
-#endif
+
+        public int GetHashCode([DisallowNull] string alternate)
+        {
+            return alternate.GetHashCode(StringComparison.OrdinalIgnoreCase);
+        }
+        /// <summary>
+        /// Returns a hash code for the specified wildcard.
+        /// </summary>
+        /// <param name="obj">The wildcard for which a hash code is to be returned.</param>
+        /// <returns>A hash code for the specified wildcard.</returns>
+        public int GetHashCode(Wildcard obj)
+        {
+            return obj.GetHashCode();
+        }
     }
 }

--- a/src/MG.Sonarr.Next/Extensions/ArrayExtensions.cs
+++ b/src/MG.Sonarr.Next/Extensions/ArrayExtensions.cs
@@ -5,6 +5,16 @@ namespace MG.Sonarr.Next.Extensions;
 public static class ArrayExtensions
 {
     /// <summary>
+    /// Determines whether the specified array is null or has a length of zero.
+    /// </summary>
+    /// <param name="array">The array to test for nullity or emptiness.</param>
+    /// <returns>true if the array is null or has a length of zero; otherwise, false.</returns>
+    public static bool IsNullOrEmpty([NotNullWhen(false)] this Array? array)
+    {
+        return array is null || array.Length == 0;
+    }
+
+    /// <summary>
     /// Removes all <see langword="null"/> elements from the specified array.
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>

--- a/src/MG.Sonarr.Next/Extensions/CollectionExtensions.cs
+++ b/src/MG.Sonarr.Next/Extensions/CollectionExtensions.cs
@@ -19,7 +19,7 @@
         /// </returns>
         public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IReadOnlyCollection<T>? collection)
         {
-            return collection is null || collection.Count <= 0;
+            return collection is null || collection.Count == 0;
         }
     }
 }

--- a/src/MG.Sonarr.Next/Extensions/PSO/PSOExtensions-Other.cs
+++ b/src/MG.Sonarr.Next/Extensions/PSO/PSOExtensions-Other.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System.Collections;
+using System.Management.Automation;
 using System.Runtime.CompilerServices;
 
 namespace MG.Sonarr.Next.Extensions.PSO
@@ -50,6 +51,57 @@ namespace MG.Sonarr.Next.Extensions.PSO
             }
 
             prop.Value = value;
+        }
+
+        [return: NotNullIfNotNull(nameof(pso))]
+        public static Dictionary<string, object?>? ToDictionary(this PSObject? pso, params ReadOnlySpan<string> ignoreKeys)
+        {
+            if (pso is null) return null;
+
+            Dictionary<string, object?> dic = new(StringComparer.OrdinalIgnoreCase);
+            foreach (PSPropertyInfo prop in pso.Properties)
+            {
+                if (ignoreKeys.Contains(prop.Name))
+                {
+                    continue;
+                }
+
+                if (prop.Value is null)
+                {
+                    dic.TryAdd(prop.Name, prop.Value);
+                    continue;
+                }
+
+                object val = prop.Value switch
+                {
+                    PSObject innerPso => ToDictionary(innerPso, ignoreKeys),
+                    string str => str,
+                    IEnumerable collection => ProcessCollection(collection, ignoreKeys),
+                    _ => prop.Value
+                };
+
+                dic.TryAdd(prop.Name, val);
+            }
+
+            return dic;
+        }
+
+        private static List<object?> ProcessCollection(IEnumerable collection, ReadOnlySpan<string> ignoreKeys)
+        {
+            List<object?> list = [];
+            foreach (object? item in collection)
+            {
+                object? val = item switch
+                {
+                    PSObject innerPso => ToDictionary(innerPso, ignoreKeys),
+                    string str => str,
+                    IEnumerable innerCollection => ProcessCollection(innerCollection, ignoreKeys),
+                    _ => item
+                };
+
+                list.Add(val);
+            }
+            return list;
         }
 
         [DebuggerStepThrough]

--- a/src/MG.Sonarr.Next/Extensions/SortedSetExtensions.cs
+++ b/src/MG.Sonarr.Next/Extensions/SortedSetExtensions.cs
@@ -1,0 +1,45 @@
+﻿using MG.Sonarr.Next.Metadata;
+using MG.Sonarr.Next.Models;
+
+namespace MG.Sonarr.Next.Extensions
+{
+    public static class SortedSetExtensions
+    {
+        public static void AddRange(this SortedSet<int> ids, ISeriesPipeable[] collection)
+        {
+            foreach (ISeriesPipeable piped in collection.AsSpan())
+            {
+                _ = ids.Add(piped.SeriesId);
+            }
+        }
+        public static void AddRange(this SortedSet<int> ids, IHasId[] collection)
+        {
+            foreach (IHasId piped in collection.AsSpan())
+            {
+                _ = ids.Add(piped.Id);
+            }
+        }
+       
+        public static void AddRange(this SortedSet<int> ids, ILanguageProfilePipeable[] collection)
+        {
+            foreach (ILanguageProfilePipeable piped in collection.AsSpan())
+            {
+                _ = ids.Add(piped.LanguageProfileId);
+            }
+        }
+        public static void AddRange(this SortedSet<int> ids, IReleasePipeableBySeries[] collection)
+        {
+            foreach (IReleasePipeableBySeries piped in collection.AsSpan())
+            {
+                _ = ids.Add(piped.SeriesId);
+            }
+        }
+        public static void AddRange(this SortedSet<int> ids, IReleasePipeableByEpisode[] collection)
+        {
+            foreach (IReleasePipeableByEpisode piped in collection.AsSpan())
+            {
+                _ = ids.Add(piped.EpisodeId);
+            }
+        }
+    }
+}

--- a/src/MG.Sonarr.Next/Json/Converters/ObjectConverter.cs
+++ b/src/MG.Sonarr.Next/Json/Converters/ObjectConverter.cs
@@ -421,10 +421,13 @@ namespace MG.Sonarr.Next.Json.Converters
 
             writer.WriteStartObject();
 
-            foreach (var prop in pso.Properties
-                .Where(static x => x.MemberType == PSMemberTypes.NoteProperty
-                            &&
-                            x.IsGettable))
+            PSPropertyInfo[] props = [.. pso.Properties.Where(x => x.MemberType == PSMemberTypes.NoteProperty && x.IsGettable)];
+            bool containsMetadata = props.Any(x => x.Name == "MetadataTag");
+            //foreach (var prop in pso.Properties
+            //    .Where(static x => x.MemberType == PSMemberTypes.NoteProperty
+            //                &&
+            //                x.IsGettable))
+            foreach (PSPropertyInfo prop in props)
             {
                 if (_config.IgnoreProperties.Contains(prop.Name))
                 {

--- a/src/MG.Sonarr.Next/Json/Converters/Spans/AlwaysStringConverter.cs
+++ b/src/MG.Sonarr.Next/Json/Converters/Spans/AlwaysStringConverter.cs
@@ -4,7 +4,10 @@
     {
         public override string? ConvertSpan(Span<char> chars, ReadOnlySpan<char> propertyName, bool isNull)
         {
-            return new string(chars.Trim());
+            chars = chars.Trim();
+            return chars.IsEmpty
+                ? string.Empty
+                : new string(chars);
         }
     }
 }

--- a/src/MG.Sonarr.Next/Json/SonarrJsonOptions.cs
+++ b/src/MG.Sonarr.Next/Json/SonarrJsonOptions.cs
@@ -128,12 +128,16 @@ namespace MG.Sonarr.Next.Json
                       .AddIgnoreProperties(EnumerateIgnoreProperties())
                       .AddSpanConverters(
                             new("AirDate", doSpanConverter),
+                            new("Certification", alwaysStringConverter),
                             new("FirstAired", doSpanConverter),
                             new("AirTime", timeConverter),
                             new("Duration", timeSpanConverter),
                             new("ApiKey", alwaysStringConverter),
                             new("DownloadId", alwaysStringConverter),
                             new("ReleaseHash", alwaysStringConverter),
+                            new("CleanTitle", alwaysStringConverter),
+                            new("SortTitle", alwaysStringConverter),
+                            new("Title", alwaysStringConverter),
                             new("TorrentInfoHash", alwaysStringConverter)
                       );
             });

--- a/src/MG.Sonarr.Next/Json/SonarrJsonOptions.cs
+++ b/src/MG.Sonarr.Next/Json/SonarrJsonOptions.cs
@@ -46,6 +46,7 @@ namespace MG.Sonarr.Next.Json
             this.ForSerializing = new(this.ForDeserializing)
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNameCaseInsensitive = true,
                 WriteIndented = false,
             };

--- a/src/MG.Sonarr.Next/Json/SonarrJsonOptions.cs
+++ b/src/MG.Sonarr.Next/Json/SonarrJsonOptions.cs
@@ -9,6 +9,7 @@ using MG.Sonarr.Next.Metadata;
 using MG.Sonarr.Next.Models;
 using MG.Sonarr.Next.Models.Episodes;
 using MG.Sonarr.Next.Models.Fields;
+using MG.Sonarr.Next.Models.ManualImports;
 using MG.Sonarr.Next.Reflection;
 using MG.Sonarr.Resources;
 using Microsoft.Extensions.DependencyInjection;
@@ -147,6 +148,7 @@ namespace MG.Sonarr.Next.Json
                 new PostCommandWriter(),
                 new SonarrResponseConverter(),
                 new ImmutableArrayConverter<FieldObject>(),
+                new ImmutableArrayConverter<ManualImportObject>(),
                 new ImmutableArrayConverter<SelectOptionObject>());
 
             List<JsonConverter> sonarrConverters = ConstructSonarrObjectConverters(objCon);

--- a/src/MG.Sonarr.Next/Models/ManualImports/ManualImportObject.cs
+++ b/src/MG.Sonarr.Next/Models/ManualImports/ManualImportObject.cs
@@ -64,6 +64,16 @@ namespace MG.Sonarr.Next.Models.ManualImports
         {
             return resolver[Meta.MANUAL_IMPORT];
         }
+
+        public bool IsReadyToPost()
+        {
+            return this.Episodes.Count > 0
+                && this.Series is SeriesObject sObj
+                && sObj.Id > 0
+                && this.Quality is QualityRevisionObject qRev
+                && qRev.Quality.Id > 0;
+        }
+
         protected override void OnDeserialized(bool alreadyCalled)
         {
             base.OnDeserialized(alreadyCalled);
@@ -82,10 +92,9 @@ namespace MG.Sonarr.Next.Models.ManualImports
 
         private void AddMissingProperties()
         {
-            var setProp = CreateIfMissing(this.Properties, EPISODES, (name) =>
+            var setProp = CreateIfMissing(this.Properties, EPISODES, static (name) =>
             {
-                return new ReadOnlyCollectionProperty<EpisodeObject, SortedSet<EpisodeObject>>(
-                    EPISODES, new SortedSet<EpisodeObject>());
+                return new ReadOnlyCollectionProperty<EpisodeObject, SortedSet<EpisodeObject>>(EPISODES, []);
             });
 
             this.Episodes = (SortedSet<EpisodeObject>)setProp.Value;
@@ -94,9 +103,9 @@ namespace MG.Sonarr.Next.Models.ManualImports
             {
                 return new WritableSonarrProperty<QualityRevisionObject>(QUALITY);
             });
-            CreateIfMissing(this.Properties, RELEASE_GROUP, (name) => new StringNoteProperty(name, string.Empty));
-            CreateIfMissing(this.Properties, SERIES, (name) => new WritableSonarrProperty<SeriesObject>(name));
-            CreateIfMissing(this.Properties, SEASON_NUMBER, (name) =>
+            CreateIfMissing(this.Properties, RELEASE_GROUP, static (name) => new StringNoteProperty(name, string.Empty));
+            CreateIfMissing(this.Properties, SERIES, static (name) => new WritableSonarrProperty<SeriesObject>(name));
+            CreateIfMissing(this.Properties, SEASON_NUMBER, static (name) =>
             {
                 return new PSScriptProperty(name,
                     ScriptBlock.Create("if (0 -lt $this.Episodes.Count) { $this.Episodes[0].SeasonNumber }"));

--- a/src/MG.Sonarr.Next/Models/ManualImports/ManualImportPost.cs
+++ b/src/MG.Sonarr.Next/Models/ManualImports/ManualImportPost.cs
@@ -1,0 +1,48 @@
+using MG.Sonarr.Next.Extensions.PSO;
+using MG.Sonarr.Next.Metadata;
+using MG.Sonarr.Next.Models.Profiles;
+using MG.Sonarr.Next.Models.Qualities;
+using System.Management.Automation;
+
+namespace MG.Sonarr.Next.Models.ManualImports
+{
+    public sealed class ManualImportPost
+    {
+        public required string Path { get; set; }
+        public required int SeriesId { get; set; }
+        public required int[] EpisodeIds { get; set; }
+        public required Dictionary<string, object?> Quality { get; set; }
+        public required Dictionary<string, object?>[] Languages { get; set; }
+        public required string ReleaseGroup { get; set; }
+        public required int IndexerFlags { get; set; }
+        public required string ReleaseType { get; set; }
+    }
+
+    public static class ManualImportPostMapper
+    {
+        public static ManualImportPost[] ToManualImportFiles(this MetadataList<ManualImportObject> list)
+        {
+            ArgumentNullException.ThrowIfNull(list);
+
+            ManualImportPost[] array = new ManualImportPost[list.Count];
+            for (int i = 0; i < list.Count; i++)
+            {
+                var obj = list[i];
+                array[i] = new()
+                {
+                    EpisodeIds = [.. obj.Episodes.Select(x => x.Id)],
+                    IndexerFlags = obj.GetValue<int>("IndexerFlags"),
+                    Languages = obj.GetValue<PSObject[]>(nameof(ManualImportPost.Languages))?.Select(x => x.ToDictionary(nameof(LanguageProfileObject.MetadataTag))).ToArray() ?? [],
+                    Path = obj.GetValue<string>(nameof(ManualImportPost.Path)) ?? throw new ArgumentException("Path cannot be null."),
+                    Quality = obj.Quality?.ToDictionary(nameof(QualityRevisionObject.MetadataTag)) ?? throw new ArgumentException("Quality cannot be null."),
+                    ReleaseGroup = obj.GetValue<string>(nameof(ManualImportPost.ReleaseGroup)) ?? string.Empty,
+                    ReleaseType = obj.GetValue<string>(nameof(ManualImportPost.ReleaseType)) ?? string.Empty,
+                    SeriesId = obj.Series?.Id ?? throw new ArgumentException("Series cannot be null."),
+                };
+            }
+
+            return array;
+        }
+    }
+}
+

--- a/src/MG.Sonarr.Next/Services/Http/Clients/SonarrHttpClient-Async.cs
+++ b/src/MG.Sonarr.Next/Services/Http/Clients/SonarrHttpClient-Async.cs
@@ -5,6 +5,7 @@ using MG.Sonarr.Next.Services.Http.Requests;
 using System.Management.Automation;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 
 namespace MG.Sonarr.Next.Services.Http.Clients
 {
@@ -59,7 +60,10 @@ namespace MG.Sonarr.Next.Services.Http.Clients
         public Task<SonarrClientResult> SendPostAsync<T>(string path, T body, CancellationToken token = default) where T : notnull
         {
             using ApiKeyRequestMessage request = new(HttpMethod.Post, path, _scopeFactory);
-            request.Content = JsonContent.Create(body, body.GetType(), options: _options.ForSerializing);
+            string json = JsonSerializer.Serialize(body, _options.ForSerializing);
+
+            //request.Content = JsonContent.Create(body, body.GetType(), options: _options.ForSerializing);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
             return this.SendNoResultRequestAsync(request, path, token);
         }

--- a/src/MG.Sonarr.Next/Services/Http/Handlers/ErrorHandler.cs
+++ b/src/MG.Sonarr.Next/Services/Http/Handlers/ErrorHandler.cs
@@ -53,11 +53,8 @@ namespace MG.Sonarr.Next.Services.Http.Handlers
 
         private static bool IsJsonType([NotNullWhen(true)] MediaTypeHeaderValue? mediaType)
         {
-            if (mediaType is null || string.IsNullOrEmpty(mediaType.MediaType))
-                return false;
-
-            string type = mediaType.MediaType;
-            return type.TryLastIndexOf(JSON, StringComparison.OrdinalIgnoreCase, out int index)
+            return mediaType?.MediaType is string type
+                && type.TryLastIndexOf(JSON, StringComparison.OrdinalIgnoreCase, out int index)
                 && index != 0
                 && type[index - 1] is '/' or '+';
         }
@@ -71,6 +68,7 @@ namespace MG.Sonarr.Next.Services.Http.Handlers
 
             using HttpContent originalContent = response.Content;
             Stream stream = await originalContent.ReadAsStreamAsync(token).ConfigureAwait(false);
+
             MemoryStream mem = new(STREAM_BUFFER_SIZE);
             await stream.CopyToAsync(mem, cancellationToken: token).ConfigureAwait(false);
 

--- a/src/MG.Sonarr.Next/Strings/Wildcard-EqualityAndOperators.cs
+++ b/src/MG.Sonarr.Next/Strings/Wildcard-EqualityAndOperators.cs
@@ -137,7 +137,7 @@ public readonly partial struct Wildcard
 	[DebuggerStepThrough]
 	public static implicit operator Wildcard(string? pattern)
 	{
-		return !string.IsNullOrEmpty(pattern) ? new Wildcard(pattern) : Empty;
+		return Parse(pattern);
 	}
 	/// <summary>
 	/// Explicitly converts a <see cref="Wildcard"/> instance to a <see cref="string"/>.

--- a/src/MG.Sonarr.Next/Strings/Wildcard-Parsing.cs
+++ b/src/MG.Sonarr.Next/Strings/Wildcard-Parsing.cs
@@ -16,21 +16,12 @@ public readonly partial struct Wildcard
 	/// </returns>
 	public static Wildcard Parse(params ReadOnlySpan<char> s)
 	{
-		if (s.IsEmpty)
+		return s.Length switch
 		{
-			return Empty;
-		}
-
-		if (s.Length == 1)
-		{
-			char c = s[0];
-			if ('*' == c || '%' == c)
-			{
-				return All;
-			}
-		}
-
-		return new(s);
+			0 => Empty,
+			1 when s[0] is '*' or '%' => All,
+			_ => new(s),
+		};
 	}
 	/// <summary>
 	/// Parses the provided <see cref="string"/> instance in a <see cref="Wildcard"/> pattern.
@@ -43,10 +34,10 @@ public readonly partial struct Wildcard
 	[DebuggerStepThrough]
 	public static Wildcard Parse(string? s)
 	{
-		return s switch
+		return s?.Length switch
 		{
-			null or "" => Empty,
-			_ when s.Length == 1 && (s[0] == '*' || s[0] == '%') => All,
+			null or 0 => Empty,
+			1 when s[0] is '*' or '%' => All,
 			_ => new(s),
 		};
 	}

--- a/src/MG.Sonarr.Next/Strings/Wildcard.cs
+++ b/src/MG.Sonarr.Next/Strings/Wildcard.cs
@@ -91,7 +91,7 @@ public readonly partial struct Wildcard :
 	//[DebuggerStepThrough]
 	public Wildcard(string? patternString)
 	{
-		WildcardMatchType matchType = DeterminePattern(patternString.AsSpan().Trim());
+		WildcardMatchType matchType = DeterminePattern(patternString.AsSpan());
 		int length = 0;
 		_pattern = ConstructPattern(patternString, matchType, ref length);
 		_state = new(length: length, type: matchType);
@@ -109,7 +109,7 @@ public readonly partial struct Wildcard :
 	//[DebuggerStepThrough]
 	public Wildcard(ReadOnlySpan<char> pattern)
 	{
-		WildcardMatchType matchType = DeterminePattern(pattern.Trim());
+		WildcardMatchType matchType = DeterminePattern(pattern);
 		int length = 0;
 		_pattern = ConstructPattern(pattern, matchType, ref length);
 		_state = new(length: length, type: matchType);


### PR DESCRIPTION
This pull request refactors several cmdlets and utility methods to simplify parameter handling, improve code clarity, and update array initialization styles. The most significant changes involve removing or replacing expression-based parameter checks with more direct property checks, updating array property initializations to use nullable or empty arrays as appropriate, and making minor improvements for code quality and maintainability.

### Adds new cmdlet:
* **Invoke-SonarrManualImport**

### Parameter handling and code simplification:

* Replaced usage of expression-based `HasParameter` methods with direct property checks (e.g., `this.Today`, `this.Tomorrow`, `this.Refresh`, `this.All`) across multiple cmdlets for improved readability and maintainability. (`GetSonarrCalendarCmdlet.cs`, `GetSonarrCommandCmdlet.cs`, `GetSonarrCommandHistory.cs`) [[1]](diffhunk://#diff-a1dd0cfe68f95e0dabcf4f8497da966426a9c43a1234f0b0897062e38e6738d7L80-R85) [[2]](diffhunk://#diff-0838616481be4c2c8fe00c332089b11f4f5e63ac559dc652b387c7819e6149c9L24-R28) [[3]](diffhunk://#diff-1f62623a5ffe54b91a9f7c18a4142e5bdd08e3551b33465806aada0c3f111115R41-R49)
* Removed or commented out unused or redundant extension methods related to parameter checking, such as `HasParameter` and `SetValue`, from `PSCmdletExtensions.cs`. [[1]](diffhunk://#diff-f069ff1de52866eca9364eacbd0561fe76e2b9fb7998a83045c12fb7ea98cc3aL67-R90) [[2]](diffhunk://#diff-f069ff1de52866eca9364eacbd0561fe76e2b9fb7998a83045c12fb7ea98cc3aL110-L135)

### Array property initialization updates:

* Changed several array properties to use nullable arrays or empty array initializers for consistency and correctness (e.g., `DayOfWeek[]? DayOfWeek`, `SeasonEpisodeId[]? EpisodeIdentifier`, and others). (`GetSonarrCalendarCmdlet.cs`, `GetSonarrEpisodeCmdlet.cs`, `RemoveSonarrDownloadClientCmdlet.cs`, `RemoveSonarrEpisodeFileCmdlet.cs`) [[1]](diffhunk://#diff-a1dd0cfe68f95e0dabcf4f8497da966426a9c43a1234f0b0897062e38e6738d7L37-R37) [[2]](diffhunk://#diff-46ac4336fe8852d5daf56f0a028dce59179ce197b545566af0216d4cf22c6a60L49-R49) [[3]](diffhunk://#diff-d2bcf22e2734cf588d99a43fdec75880fd77a87a41cf04dabfba91f5c2d2903bL18-R22) [[4]](diffhunk://#diff-55764ac75335fce378da48e8109bebe64fff98a8213167e144d9483b04f5e059L20-R24)

### Suppression and style improvements:

* Added `SuppressMessage` attributes to certain overridden methods to address style warnings and clarify intentional usage of implicit member access. [[1]](diffhunk://#diff-a1dd0cfe68f95e0dabcf4f8497da966426a9c43a1234f0b0897062e38e6738d7R103) [[2]](diffhunk://#diff-1f62623a5ffe54b91a9f7c18a4142e5bdd08e3551b33465806aada0c3f111115R41-R49) [[3]](diffhunk://#diff-d2bcf22e2734cf588d99a43fdec75880fd77a87a41cf04dabfba91f5c2d2903bR42-R50) [[4]](diffhunk://#diff-55764ac75335fce378da48e8109bebe64fff98a8213167e144d9483b04f5e059R45-R48) [[5]](diffhunk://#diff-46ac4336fe8852d5daf56f0a028dce59179ce197b545566af0216d4cf22c6a60L64-R67) [[6]](diffhunk://#diff-46ac4336fe8852d5daf56f0a028dce59179ce197b545566af0216d4cf22c6a60L94-R94) [[7]](diffhunk://#diff-e217860161b58c9a1f5c59eb26d4ef42c6f4f2fa61e68f71f15f69ea71946ec2L109-R125)

### Minor code and logic fixes:

* Updated method signatures and variable usage for clarity, such as removing unnecessary `in` modifiers and using direct assignments instead of references. (`SendPutRequest`, `TryCommitFromResponse`, `DeleteDownloadClient`, `UpdateClient`, `SendUpdate`, and related methods) [[1]](diffhunk://#diff-bd139bdb67974c85abfc0b31a25a1062043a09aaf98e3d36250c3676c7ff3eb4L150-R150) [[2]](diffhunk://#diff-21f4198e3c4bd7c91f1755c9844366ed26c1f271a52dcf79f7177494493049f8L39-R39) [[3]](diffhunk://#diff-d2bcf22e2734cf588d99a43fdec75880fd77a87a41cf04dabfba91f5c2d2903bL59-R67) [[4]](diffhunk://#diff-587221ecac492a653bd2e2feebf2c1987997ab97723f6448fc11b9117cf0d8bbR44-R52)
* Improved filtering and validation logic, such as removing the use of `ref readonly` in loops and enhancing null/length checks before processing arrays. (`GetAllAndFilter`, `GetSonarrEpisodeCmdlet.cs`) [[1]](diffhunk://#diff-b970948d9c92dd41bf17f523c7b22e70ae02319ea97d5abd1b940be7a89e5eddL59-R59) [[2]](diffhunk://#diff-46ac4336fe8852d5daf56f0a028dce59179ce197b545566af0216d4cf22c6a60L64-R67) [[3]](diffhunk://#diff-46ac4336fe8852d5daf56f0a028dce59179ce197b545566af0216d4cf22c6a60L106-R106)